### PR TITLE
Expose fixture executor to make references available

### DIFF
--- a/src/Codeception/Module/Doctrine2.php
+++ b/src/Codeception/Module/Doctrine2.php
@@ -685,6 +685,7 @@ EOF;
      *
      * @param string|string[]|object[] $fixtures
      * @param bool $append
+     * @return ORMExecutor
      * @throws ModuleException
      * @throws ModuleRequireException
      */
@@ -785,6 +786,7 @@ EOF;
             $purger = new ORMPurger($this->em);
             $executor = new ORMExecutor($this->em, $purger);
             $executor->execute($loader->getFixtures(), $append);
+            return $executor;
         } catch (Exception $e) {
             throw new ModuleException(
                 __CLASS__,

--- a/tests/data/doctrine2_fixtures/SharedTestFixture1.php
+++ b/tests/data/doctrine2_fixtures/SharedTestFixture1.php
@@ -1,0 +1,17 @@
+<?php
+
+use Doctrine\Common\DataFixtures\AbstractFixture;
+use Doctrine\Common\Persistence\ObjectManager;
+
+class SharedTestFixture1 extends AbstractFixture
+{
+    public function load(ObjectManager $manager)
+    {
+        $entity = new PlainEntity();
+        $entity->setName('from SharedTestFixture1');
+        $manager->persist($entity);
+        $manager->flush();
+
+        $this->addReference('shared-testfixture-1', $entity);
+    }
+}

--- a/tests/data/doctrine2_fixtures/SharedTestFixture2.php
+++ b/tests/data/doctrine2_fixtures/SharedTestFixture2.php
@@ -1,0 +1,17 @@
+<?php
+
+use Doctrine\Common\DataFixtures\AbstractFixture;
+use Doctrine\Common\Persistence\ObjectManager;
+
+class SharedTestFixture2 extends AbstractFixture
+{
+    public function load(ObjectManager $manager)
+    {
+        $entity = new PlainEntity();
+        $entity->setName('from SharedTestFixture2');
+        $manager->persist($entity);
+        $manager->flush();
+
+        $this->addReference('shared-testfixture-2', $entity);
+    }
+}

--- a/tests/unit/Codeception/Module/Doctrine2Test.php
+++ b/tests/unit/Codeception/Module/Doctrine2Test.php
@@ -1,4 +1,4 @@
-<?php
+›<?php
 
 use Codeception\Exception\ModuleException;
 use Codeception\Module\Doctrine2;
@@ -115,6 +115,8 @@ class Doctrine2Test extends Unit
 
         require_once $dir . "/TestFixture1.php";
         require_once $dir . "/TestFixture2.php";
+        require_once $dir . "/SharedTestFixture1.php";
+        require_once $dir . "/SharedTestFixture2.php";
     }
 
     public function testPlainEntity()
@@ -555,5 +557,19 @@ class Doctrine2Test extends Unit
         $this->assertSame($bbb1->getA(), $aaa);
         $this->assertSame($bbb2->getA(), $aaa);
         $this->assertSame($ccc->getB(), $bbb2);
+    }
+
+    public function testReferenceAccess()
+    {
+        $this->_preloadFixtures();
+
+        $executor = $this->module->loadFixtures([SharedTestFixture1::class, SharedTestFixture2::class]);
+        $repository = $executor->getReferenceRepository();
+
+        $sharedFixture1 = $repository->getReference('shared-testfixture-1');
+        $sharedFixture2 = $repository->getReference('shared-testfixture-2');
+
+        $this->assertEquals('from SharedTestFixture1', $sharedFixture1->getName());
+        $this->assertEquals('from SharedTestFixture2', $sharedFixture2->getName());
     }
 }


### PR DESCRIPTION
With returning the `ORMExecutor` after loading fixtures it is possible to access the `ReferenceRepository` which in turn allows fetching concrete fixture instances by reference:

```php
/** @var \Doctrine\Common\DataFixtures\ReferenceRepository $repo */
$repo = $I->loadFixtures(Foo::class)->getReferenceRepository();
/** @var Foo $foo */
$foo = $repo->getReference('foo');
```

which comes in very handy. See the included UnitTest for an example.

Edit: I don't know why Travis fails, local tests don't
