### PR TITLE
Correcting \Doctrine\Common\Persistence\Mapping\MappingException to \…

### DIFF
--- a/src/Codeception/Module/Doctrine2.php
+++ b/src/Codeception/Module/Doctrine2.php
@@ -1072,7 +1072,7 @@ EOF;
                 $this->em->getClassMetadata(get_class($pk));
             } catch (\Doctrine\ORM\Mapping\MappingException $ex) {
                 $isEntity = false;
-            } catch (\Doctrine\Common\Persistence\Mapping\MappingException $ex) {
+            } catch (\Doctrine\Persistence\Mapping\MappingException $ex) {
                 $isEntity = false;
             }
         }

--- a/src/Codeception/Module/Doctrine2.php
+++ b/src/Codeception/Module/Doctrine2.php
@@ -1072,6 +1072,8 @@ EOF;
                 $this->em->getClassMetadata(get_class($pk));
             } catch (\Doctrine\ORM\Mapping\MappingException $ex) {
                 $isEntity = false;
+            } catch (\Doctrine\Common\Persistence\Mapping\MappingException $ex) {
+                $isEntity = false;
             } catch (\Doctrine\Persistence\Mapping\MappingException $ex) {
                 $isEntity = false;
             }


### PR DESCRIPTION
Changed 
\Doctrine\Common\Persistence\Mapping\MappingException

to:

\Doctrine\Persistence\Mapping\MappingException

The first doesn't exist in Doctrine\Common. This is related to issue https://github.com/Codeception/Codeception/issues/5691
which still affected my repo when I my entity inherited the id from a superclass. Correcting the exception fixes the issue.