### PR TITLE
Fix Fatal error: Uncaught Error: Class 'Doctrine\Common\DataFixtures\Purger\ORMPurger' not found in

### DIFF
--- a/src/Codeception/Module/Doctrine2.php
+++ b/src/Codeception/Module/Doctrine2.php
@@ -138,7 +138,7 @@ class Doctrine2 extends CodeceptionModule implements DependsOnModule, DataMapper
         'cleanup' => true,
         'connection_callback' => false,
         'depends' => null,
-        'purge_mode' => ORMPurger::PURGE_MODE_DELETE,
+        'purge_mode' => 1, // ORMPurger::PURGE_MODE_DELETE
     ];
 
     protected $dependencyMessage = <<<EOF


### PR DESCRIPTION
Implicit dependency on doctrine/data-fixtures was introduced in this commit https://github.com/Codeception/module-doctrine2/commit/1ae32bdcd77abde4a583462f5949fc86b9bda2a2.
If I don't have doctrine/data-fixtures installed, I'm given error `Fatal error: Uncaught Error: Class 'Doctrine\Common\DataFixtures\Purger\ORMPurger' not found in`.