### PR TITLE
Code standards updated to PHP 7.1

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,7 +8,7 @@ jobs:
 
     strategy:
       matrix:
-        php: [5.6, 7.0, 7.1, 7.2, 7.3, 7.4, 8.0]
+        php: [7.1, 7.2, 7.3, 7.4, 8.0]
 
     steps:
     - name: Checkout code
@@ -24,13 +24,8 @@ jobs:
     - name: Validate composer.json and composer.lock
       run: composer validate
 
-    - name: Install dependencies on PHP 7
-      if: matrix.php < 8
+    - name: Install dependencies
       run: composer install --prefer-dist --no-progress --no-interaction
-
-    - name: Install dependencies on PHP 8
-      if: matrix.php == 8
-      run: composer install --prefer-dist --no-progress --no-interaction --ignore-platform-req=php
 
     - name: Run test suite
       run: php vendor/bin/codecept run

--- a/composer.json
+++ b/composer.json
@@ -1,11 +1,11 @@
 {
-    "name":"codeception/module-doctrine2",
-    "description":"Doctrine2 module for Codeception",
-    "keywords":["codeception", "doctrine2"],
-    "homepage":"http://codeception.com/",
-    "type":"library",
-    "license":"MIT",
-    "authors":[
+    "name": "codeception/module-doctrine2",
+    "description": "Doctrine2 module for Codeception",
+    "keywords": [ "codeception", "doctrine2" ],
+    "homepage": "https://codeception.com/",
+    "type": "library",
+    "license": "MIT",
+    "authors": [
         {
             "name":"Michael Bodnarchuk"
         },
@@ -15,7 +15,9 @@
     ],
     "minimum-stability": "RC",
     "require": {
-        "php": ">=5.6.0 <9.0",
+        "php": "^7.1 || ^8.0",
+        "ext-pdo": "*",
+        "ext-json": "*",
         "codeception/codeception": "^4.0"
     },
     "require-dev": {
@@ -24,8 +26,8 @@
         "doctrine/data-fixtures": "^1",
         "ramsey/uuid-doctrine": "^1.5"
     },
-    "autoload":{
-        "classmap": ["src/"]
+    "autoload": {
+        "classmap": [ "src/" ]
     },
     "config": {
         "classmap-authoritative": true

--- a/readme.md
+++ b/readme.md
@@ -7,6 +7,10 @@ A Doctrine 2 module for Codeception.
 [![Total Downloads](https://poser.pugx.org/codeception/module-doctrine2/downloads)](https://packagist.org/packages/codeception/module-doctrine2)
 [![License](https://poser.pugx.org/codeception/module-doctrine2/license)](/LICENSE)
 
+## Requirements
+
+* `PHP 7.1` or higher.
+
 ## Installation
 
 ```

--- a/src/Codeception/Module/Doctrine2.php
+++ b/src/Codeception/Module/Doctrine2.php
@@ -365,14 +365,14 @@ EOF;
      * This creates a stub class for Entity\User repository with redefined method findByUsername,
      * which will always return the NULL value.
      *
-     * @param $classname
+     * @param string $className
      * @param array $methods
      */
-    public function haveFakeRepository($classname, array $methods = []): void
+    public function haveFakeRepository(string $className, array $methods = []): void
     {
         $em = $this->em;
 
-        $metadata = $em->getMetadataFactory()->getMetadataFor($classname);
+        $metadata = $em->getMetadataFactory()->getMetadataFor($className);
         $customRepositoryClassName = $metadata->customRepositoryClassName;
 
         if (!$customRepositoryClassName) {
@@ -400,7 +400,7 @@ EOF;
 
             $property = $reflectedEm->getProperty('repositories');
             $property->setAccessible(true);
-            $property->setValue($em, array_merge($property->getValue($em), [$classname => $mock]));
+            $property->setValue($em, array_merge($property->getValue($em), [$className => $mock]));
         } elseif ($reflectedEm->hasProperty('repositoryFactory')) {
             //For doctrine 2.4.0+ versions
 
@@ -416,7 +416,7 @@ EOF;
 
                 $repositoryListProperty->setValue(
                     $repositoryFactory,
-                    [$classname => $mock]
+                    [$className => $mock]
                 );
 
                 $repositoryFactoryProperty->setValue($em, $repositoryFactory);

--- a/src/Codeception/Module/Doctrine2.php
+++ b/src/Codeception/Module/Doctrine2.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Codeception\Module;
 
 use Codeception\Exception\ModuleConfigException;
@@ -8,7 +10,6 @@ use Codeception\Exception\ModuleRequireException;
 use Codeception\Lib\Interfaces\DataMapper;
 use Codeception\Lib\Interfaces\DependsOnModule;
 use Codeception\Lib\Interfaces\DoctrineProvider;
-use Codeception\Lib\Notification;
 use Codeception\Module as CodeceptionModule;
 use Codeception\TestInterface;
 use Codeception\Util\ReflectionPropertyAccessor;
@@ -164,7 +165,7 @@ EOF;
     public $em = null;
 
     /**
-     * @var \Codeception\Lib\Interfaces\DoctrineProvider
+     * @var DoctrineProvider
      */
     private $dependentModule;
 
@@ -305,7 +306,7 @@ EOF;
     /**
      * Performs $em->flush();
      */
-    public function flushToDatabase()
+    public function flushToDatabase(): void
     {
         $this->em->flush();
     }
@@ -323,7 +324,7 @@ EOF;
      *
      * @param object|object[] $entities
      */
-    public function refreshEntities($entities)
+    public function refreshEntities($entities): void
     {
         if (!is_array($entities)) {
             $entities = [$entities];
@@ -341,18 +342,9 @@ EOF;
      * $I->clearEntityManager();
      * ```
      */
-    public function clearEntityManager()
+    public function clearEntityManager(): void
     {
         $this->em->clear();
-    }
-
-    /**
-     * This method is deprecated in favor of `haveInRepository()`. Its functionality is exactly the same.
-     */
-    public function persistEntity($obj, $values = [])
-    {
-        Notification::deprecate("Doctrine2::persistEntity is deprecated in favor of Doctrine2::haveInRepository");
-        return $this->haveInRepository($obj, $values);
     }
 
     /**
@@ -376,7 +368,7 @@ EOF;
      * @param $classname
      * @param array $methods
      */
-    public function haveFakeRepository($classname, $methods = [])
+    public function haveFakeRepository($classname, array $methods = []): void
     {
         $em = $this->em;
 
@@ -537,7 +529,7 @@ EOF;
      * @return object
      * @throws ReflectionException
      */
-    private function instantiateAndPopulateEntity($className, array $data, array &$instances)
+    private function instantiateAndPopulateEntity(string $className, array $data, array &$instances)
     {
         $rpa = new ReflectionPropertyAccessor();
         list($scalars,$relations) = $this->splitScalarsAndRelations($className, $data);
@@ -583,7 +575,7 @@ EOF;
      * @param array $data
      * @return array
      */
-    private function splitScalarsAndRelations($className, array $data)
+    private function splitScalarsAndRelations(string $className, array $data): array
     {
         $scalars = [];
         $relations = [];
@@ -608,7 +600,7 @@ EOF;
      * @param array &$instances
      * @return array
      */
-    private function instantiateRelations($className, $master, array $data, array &$instances)
+    private function instantiateRelations(string $className, $master, array $data, array &$instances): array
     {
         $metadata = $this->em->getClassMetadata($className);
 
@@ -691,11 +683,11 @@ EOF;
      * @throws ModuleException
      * @throws ModuleRequireException
      */
-    public function loadFixtures($fixtures, $append = true)
+    public function loadFixtures($fixtures, bool $append = true): void
     {
-        if (!class_exists(\Doctrine\Common\DataFixtures\Loader::class)
-            || !class_exists(\Doctrine\Common\DataFixtures\Purger\ORMPurger::class)
-            || !class_exists(\Doctrine\Common\DataFixtures\Executor\ORMExecutor::class)) {
+        if (!class_exists(Loader::class)
+            || !class_exists(ORMPurger::class)
+            || !class_exists(ORMExecutor::class)) {
             throw new ModuleRequireException(
                 __CLASS__,
                 'Doctrine fixtures support in unavailable.\n'
@@ -871,11 +863,10 @@ EOF;
         $this->assertNot($res);
     }
 
-    protected function proceedSeeInRepository($entity, $params = [])
+    protected function proceedSeeInRepository($entity, $params = []): array
     {
         // we need to store to database...
         $this->em->flush();
-        $data = $this->em->getClassMetadata($entity);
         $qb = $this->em->getRepository($entity)->createQueryBuilder('s');
         $this->buildAssociationQuery($qb, $entity, 's', $params);
         $this->debug($qb->getDQL());
@@ -907,7 +898,6 @@ EOF;
     {
         // we need to store to database...
         $this->em->flush();
-        $data = $this->em->getClassMetadata($entity);
         $qb = $this->em->getRepository($entity)->createQueryBuilder('s');
         $qb->select('s.' . $field);
         $this->buildAssociationQuery($qb, $entity, 's', $params);
@@ -928,16 +918,15 @@ EOF;
      * ?>
      * ```
      *
-     * @version 1.1
      * @param $entity
      * @param array $params. For `IS NULL`, use `['field' => null]`
      * @return array
+     * @version 1.1
      */
-    public function grabEntitiesFromRepository($entity, $params = [])
+    public function grabEntitiesFromRepository($entity, array $params = []): array
     {
         // we need to store to database...
         $this->em->flush();
-        $data = $this->em->getClassMetadata($entity);
         $qb = $this->em->getRepository($entity)->createQueryBuilder('s');
         $qb->select('s');
         $this->buildAssociationQuery($qb, $entity, 's', $params);
@@ -959,16 +948,15 @@ EOF;
      * ?>
      * ```
      *
-     * @version 1.1
      * @param $entity
      * @param array $params. For `IS NULL`, use `['field' => null]`
      * @return object
+     * @version 1.1
      */
-    public function grabEntityFromRepository($entity, $params = [])
+    public function grabEntityFromRepository($entity, array $params = [])
     {
         // we need to store to database...
         $this->em->flush();
-        $data = $this->em->getClassMetadata($entity);
         $qb = $this->em->getRepository($entity)->createQueryBuilder('s');
         $qb->select('s');
         $this->buildAssociationQuery($qb, $entity, 's', $params);
@@ -977,28 +965,13 @@ EOF;
         return $qb->getQuery()->getSingleResult();
     }
 
-    /**
-     * It's Fuckin Recursive!
-     *
-     * @param QueryBuilder $qb
-     * @param string $assoc
-     * @param string $alias
-     * @param array $params
-     */
-    protected function buildAssociationQuery($qb, $assoc, $alias, $params)
+    protected function buildAssociationQuery(QueryBuilder $qb, string $assoc, string $alias, array $params): void
     {
         $paramIndex = 0;
         $this->_buildAssociationQuery($qb, $assoc, $alias, $params, $paramIndex);
     }
 
-    /**
-     * @param QueryBuilder $qb
-     * @param string $assoc
-     * @param string $alias
-     * @param array $params
-     * @param int &$paramIndex
-     */
-    protected function _buildAssociationQuery($qb, $assoc, $alias, $params, &$paramIndex)
+    protected function _buildAssociationQuery(QueryBuilder $qb, string $assoc, string $alias, array $params, int &$paramIndex)
     {
         $data = $this->em->getClassMetadata($assoc);
         foreach ($params as $key => $val) {
@@ -1038,7 +1011,7 @@ EOF;
      * @param mixed $instance
      * @param mixed $pks
      *
-     * @throws \ReflectionException
+     * @throws ReflectionException
      */
     private function debugEntityCreation($instance, $pks)
     {
@@ -1064,10 +1037,9 @@ EOF;
 
     /**
      * @param mixed $pk
-     *
      * @return bool
      */
-    private function isDoctrineEntity($pk)
+    private function isDoctrineEntity($pk): bool
     {
         $isEntity = is_object($pk);
 

--- a/tests/unit/Codeception/Module/Doctrine2Test.php
+++ b/tests/unit/Codeception/Module/Doctrine2Test.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 use Codeception\Exception\ModuleException;
 use Codeception\Module\Doctrine2;
 use Codeception\Test\Unit;
@@ -12,7 +14,7 @@ use Doctrine\ORM\Tools\Setup;
 use Ramsey\Uuid\Doctrine\UuidType;
 use Ramsey\Uuid\UuidInterface;
 
-class Doctrine2Test extends Unit
+final class Doctrine2Test extends Unit
 {
     /**
      * @var EntityManager


### PR DESCRIPTION
- The minimum version of PHP is now 7.1
- Added strict types
- Added return types
- Added some typehints
- Removed deprecated method `persistEntity`
- Removed unnecessary qualifiers