### PR TITLE
Add phpstan, add/fix types

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -29,3 +29,6 @@ jobs:
 
     - name: Run test suite
       run: php vendor/bin/codecept run
+
+    - name: Run SCA
+      run: php vendor/bin/phpstan

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -30,5 +30,5 @@ jobs:
     - name: Run test suite
       run: php vendor/bin/codecept run
 
-    - name: Run SCA
+    - name: Run source code analysis
       run: php vendor/bin/phpstan

--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
         "doctrine/orm": "^2",
         "phpstan/phpstan": "^0.12.93",
         "ramsey/uuid-doctrine": "^1.5",
-        "symfony/cache": "^5.3"
+        "symfony/cache": "^4.4 || ^5.3"
     },
     "autoload": {
         "classmap": [ "src/" ]

--- a/composer.json
+++ b/composer.json
@@ -21,15 +21,18 @@
         "codeception/codeception": "^4.0"
     },
     "require-dev": {
-        "doctrine/orm": "^2",
         "doctrine/annotations": "^1",
         "doctrine/data-fixtures": "^1",
-        "ramsey/uuid-doctrine": "^1.5"
+        "doctrine/orm": "^2",
+        "phpstan/phpstan": "^0.12.93",
+        "ramsey/uuid-doctrine": "^1.5",
+        "symfony/cache": "^5.3"
     },
     "autoload": {
         "classmap": [ "src/" ]
     },
     "config": {
-        "classmap-authoritative": true
+        "classmap-authoritative": true,
+        "sort-packages": true
     }
 }

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1,0 +1,27 @@
+parameters:
+	ignoreErrors:
+		-
+			message: "#^Access to an undefined property Doctrine\\\\Persistence\\\\Mapping\\\\ClassMetadata\\:\\:\\$customRepositoryClassName\\.$#"
+			count: 1
+			path: src/Codeception/Module/Doctrine2.php
+
+		-
+			message: "#^Access to an undefined property Doctrine\\\\Persistence\\\\Mapping\\\\ClassMetadata\\:\\:\\$name\\.$#"
+			count: 1
+			path: src/Codeception/Module/Doctrine2.php
+
+		-
+			message: "#^Call to an undefined method Doctrine\\\\Persistence\\\\ObjectRepository\\:\\:createQueryBuilder\\(\\)\\.$#"
+			count: 4
+			path: src/Codeception/Module/Doctrine2.php
+
+		-
+			message: "#^Dead catch \\- Doctrine\\\\Persistence\\\\Mapping\\\\MappingException is already caught by Doctrine\\\\Persistence\\\\Mapping\\\\MappingException above\\.$#"
+			count: 1
+			path: src/Codeception/Module/Doctrine2.php
+
+		-
+			message: "#^Unable to resolve the template type T in call to method Codeception\\\\Module\\\\Doctrine2\\:\\:instantiateAndPopulateEntity\\(\\)$#"
+			count: 2
+			path: src/Codeception/Module/Doctrine2.php
+

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -6,6 +6,10 @@ parameters:
   paths:
     - src
     - tests
+  excludePaths:
+    analyse:
+        - tests/data/doctrine2_fixtures/TestFixture1.php
+        - tests/data/doctrine2_fixtures/TestFixture2.php
   checkMissingIterableValueType: false
   reportUnmatchedIgnoredErrors: false
   ignoreErrors:

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,9 +1,13 @@
+includes:
+    - phpstan-baseline.neon
+
 parameters:
   level: 6
   paths:
     - src
     - tests
   checkMissingIterableValueType: false
+  reportUnmatchedIgnoredErrors: false
   ignoreErrors:
       - path: tests/
         message: '#no typehint specified#'

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,0 +1,13 @@
+parameters:
+  level: 6
+  paths:
+    - src
+    - tests
+  checkMissingIterableValueType: false
+  ignoreErrors:
+      - path: tests/
+        message: '#no typehint specified#'
+      - path: tests/
+        message: '#no return typehint specified#'
+      - path: tests/
+        message: '#does not specify its types#'

--- a/src/Codeception/Module/Doctrine2.php
+++ b/src/Codeception/Module/Doctrine2.php
@@ -136,7 +136,9 @@ use function var_export;
 class Doctrine2 extends CodeceptionModule implements DependsOnModule, DataMapper
 {
 
-    /** @var array */
+    /**
+     * @var array
+     */
     protected $config = [
         'cleanup' => true,
         'connection_callback' => false,
@@ -144,7 +146,9 @@ class Doctrine2 extends CodeceptionModule implements DependsOnModule, DataMapper
         'purge_mode' => 1, // ORMPurger::PURGE_MODE_DELETE
     ];
 
-    /** @var string */
+    /**
+     * @var string
+     */
     protected $dependencyMessage = <<<EOF
 Provide connection_callback function to establish database connection and get Entity Manager:
 

--- a/tests/data/doctrine2_fixtures/TestFixture1.php
+++ b/tests/data/doctrine2_fixtures/TestFixture1.php
@@ -1,15 +1,27 @@
 <?php
 
 use Doctrine\Common\DataFixtures\FixtureInterface;
-use Doctrine\Persistence\ObjectManager;
 
-class TestFixture1 implements FixtureInterface
-{
-    public function load(ObjectManager $manager)
+if (PHP_VERSION_ID < 70200) {
+    class TestFixture1 implements FixtureInterface
     {
-        $entity = new PlainEntity();
-        $entity->setName('from TestFixture1');
-        $manager->persist($entity);
-        $manager->flush();
+        public function load(\Doctrine\Common\Persistence\ObjectManager $manager)
+        {
+            $entity = new PlainEntity();
+            $entity->setName('from TestFixture1');
+            $manager->persist($entity);
+            $manager->flush();
+        }
+    }
+} else {
+    class TestFixture1 implements FixtureInterface
+    {
+        public function load(\Doctrine\Persistence\ObjectManager $manager)
+        {
+            $entity = new PlainEntity();
+            $entity->setName('from TestFixture1');
+            $manager->persist($entity);
+            $manager->flush();
+        }
     }
 }

--- a/tests/data/doctrine2_fixtures/TestFixture1.php
+++ b/tests/data/doctrine2_fixtures/TestFixture1.php
@@ -1,6 +1,7 @@
 <?php
 
 use Doctrine\Common\DataFixtures\FixtureInterface;
+use Doctrine\Persistence\ObjectManager;
 
 if (version_compare(PHP_VERSION, '7.1', '>')) {
     class TestFixture1 implements FixtureInterface
@@ -16,7 +17,7 @@ if (version_compare(PHP_VERSION, '7.1', '>')) {
 } else {
     class TestFixture1 implements FixtureInterface
     {
-        public function load(Doctrine\Common\Persistence\ObjectManager $manager)
+        public function load(ObjectManager $manager)
         {
             $entity = new PlainEntity();
             $entity->setName('from TestFixture1');

--- a/tests/data/doctrine2_fixtures/TestFixture1.php
+++ b/tests/data/doctrine2_fixtures/TestFixture1.php
@@ -3,26 +3,13 @@
 use Doctrine\Common\DataFixtures\FixtureInterface;
 use Doctrine\Persistence\ObjectManager;
 
-if (version_compare(PHP_VERSION, '7.1', '>')) {
-    class TestFixture1 implements FixtureInterface
+class TestFixture1 implements FixtureInterface
+{
+    public function load(ObjectManager $manager)
     {
-        public function load(Doctrine\Persistence\ObjectManager $manager)
-        {
-            $entity = new PlainEntity();
-            $entity->setName('from TestFixture1');
-            $manager->persist($entity);
-            $manager->flush();
-        }
-    }
-} else {
-    class TestFixture1 implements FixtureInterface
-    {
-        public function load(ObjectManager $manager)
-        {
-            $entity = new PlainEntity();
-            $entity->setName('from TestFixture1');
-            $manager->persist($entity);
-            $manager->flush();
-        }
+        $entity = new PlainEntity();
+        $entity->setName('from TestFixture1');
+        $manager->persist($entity);
+        $manager->flush();
     }
 }

--- a/tests/data/doctrine2_fixtures/TestFixture2.php
+++ b/tests/data/doctrine2_fixtures/TestFixture2.php
@@ -3,27 +3,15 @@
 use Doctrine\Common\DataFixtures\FixtureInterface;
 use Doctrine\Persistence\ObjectManager;
 
-if (version_compare(PHP_VERSION, '7.1', '>')) {
-    class TestFixture2 implements FixtureInterface
+class TestFixture2 implements FixtureInterface
+{
+    public function load(ObjectManager $manager)
     {
-        public function load(Doctrine\Persistence\ObjectManager $manager)
-        {
-            $entity = new PlainEntity();
-            $entity->setName('from TestFixture2');
-            $manager->persist($entity);
-            $manager->flush();
-        }
-    }
-} else {
-    class TestFixture2 implements FixtureInterface
-    {
-        public function load(ObjectManager $manager)
-        {
-            $entity = new PlainEntity();
-            $entity->setName('from TestFixture2');
-            $manager->persist($entity);
-            $manager->flush();
-        }
+        $entity = new PlainEntity();
+        $entity->setName('from TestFixture2');
+        $manager->persist($entity);
+        $manager->flush();
     }
 }
+
 

--- a/tests/data/doctrine2_fixtures/TestFixture2.php
+++ b/tests/data/doctrine2_fixtures/TestFixture2.php
@@ -1,6 +1,7 @@
 <?php
 
 use Doctrine\Common\DataFixtures\FixtureInterface;
+use Doctrine\Persistence\ObjectManager;
 
 if (version_compare(PHP_VERSION, '7.1', '>')) {
     class TestFixture2 implements FixtureInterface
@@ -16,7 +17,7 @@ if (version_compare(PHP_VERSION, '7.1', '>')) {
 } else {
     class TestFixture2 implements FixtureInterface
     {
-        public function load(\Doctrine\Common\Persistence\ObjectManager $manager)
+        public function load(ObjectManager $manager)
         {
             $entity = new PlainEntity();
             $entity->setName('from TestFixture2');

--- a/tests/data/doctrine2_fixtures/TestFixture2.php
+++ b/tests/data/doctrine2_fixtures/TestFixture2.php
@@ -1,17 +1,27 @@
 <?php
 
 use Doctrine\Common\DataFixtures\FixtureInterface;
-use Doctrine\Persistence\ObjectManager;
 
-class TestFixture2 implements FixtureInterface
-{
-    public function load(ObjectManager $manager)
+if (PHP_VERSION_ID < 70200) {
+    class TestFixture2 implements FixtureInterface
     {
-        $entity = new PlainEntity();
-        $entity->setName('from TestFixture2');
-        $manager->persist($entity);
-        $manager->flush();
+        public function load(\Doctrine\Common\Persistence\ObjectManager $manager)
+        {
+            $entity = new PlainEntity();
+            $entity->setName('from TestFixture2');
+            $manager->persist($entity);
+            $manager->flush();
+        }
+    }
+} else {
+    class TestFixture2 implements FixtureInterface
+    {
+        public function load(\Doctrine\Persistence\ObjectManager $manager)
+        {
+            $entity = new PlainEntity();
+            $entity->setName('from TestFixture2');
+            $manager->persist($entity);
+            $manager->flush();
+        }
     }
 }
-
-

--- a/tests/unit/Codeception/Module/Doctrine2Test.php
+++ b/tests/unit/Codeception/Module/Doctrine2Test.php
@@ -351,6 +351,7 @@ final class Doctrine2Test extends Unit
         $this->_preloadFixtures();
         $this->expectException(ModuleException::class);
         $this->expectExceptionMessageRegExp('/Fixture class ".*" does not exist/');
+        // @phpstan-ignore-next-line
         $this->module->loadFixtures('InvalidFixtureClass');
     }
 
@@ -361,6 +362,7 @@ final class Doctrine2Test extends Unit
         $this->expectExceptionMessageRegExp('/Fixture class ".*" does not inherit from/');
         // Somewhat risky, but it's unlikely unit class will
         // ever inherit from a fixture interface:
+        // @phpstan-ignore-next-line
         $this->module->loadFixtures(__CLASS__);
     }
 
@@ -369,6 +371,7 @@ final class Doctrine2Test extends Unit
         $this->_preloadFixtures();
         $this->expectException(ModuleException::class);
         $this->expectExceptionMessageRegExp('/Fixture ".*" does not inherit from/');
+        // @phpstan-ignore-next-line
         $this->module->loadFixtures(new \stdClass);
     }
 
@@ -377,6 +380,7 @@ final class Doctrine2Test extends Unit
         $this->_preloadFixtures();
         $this->expectException(ModuleException::class);
         $this->expectExceptionMessageRegExp('/Fixture is expected to be .* got ".*" instead/');
+        // @phpstan-ignore-next-line
         $this->module->loadFixtures(1);
     }
 


### PR DESCRIPTION
The main goal was to provide better param/return types using `class-string` and templates, but I decided to also run PHPStan over the codebase and fix some errors reported. I think this will help to write a better code in the future.

I also had to add symfony/cache as a dev dependency, because the test suite was failing:
```
1) Doctrine2Test: Plain entity
 Test  tests/unit/Codeception/Module/Doctrine2Test.php:testPlainEntity

  [RuntimeException] Setup tool cannot configure caches without doctrine/cache 1.11 or symfony/cache. Please add an explicit dependency to either library.

#1  /Users/anatoly/PhpstormProjects/module-doctrine2/vendor/doctrine/orm/lib/Doctrine/ORM/Tools/Setup.php:184
#2  /Users/anatoly/PhpstormProjects/module-doctrine2/vendor/doctrine/orm/lib/Doctrine/ORM/Tools/Setup.php:160
#3  /Users/anatoly/PhpstormProjects/module-doctrine2/vendor/doctrine/orm/lib/Doctrine/ORM/Tools/Setup.php:139
#4  /Users/anatoly/PhpstormProjects/module-doctrine2/vendor/doctrine/orm/lib/Doctrine/ORM/Tools/Setup.php:87
#5  /Users/anatoly/PhpstormProjects/module-doctrine2/tests/unit/Codeception/Module/Doctrine2Test.php:73
```