### PR TITLE
Update hash generation due to changes in doctrine/orm

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,7 +8,7 @@ jobs:
 
     strategy:
       matrix:
-        php: [7.1, 7.2, 7.3, 7.4, 8.0]
+        php: [7.2, 7.3, 7.4, 8.0]
 
     steps:
     - name: Checkout code

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
     ],
     "minimum-stability": "RC",
     "require": {
-        "php": "^7.1 || ^8.0",
+        "php": "^7.2 || ^8.0",
         "ext-pdo": "*",
         "ext-json": "*",
         "codeception/codeception": "^4.0"
@@ -23,7 +23,7 @@
     "require-dev": {
         "doctrine/annotations": "^1",
         "doctrine/data-fixtures": "^1",
-        "doctrine/orm": "^2",
+        "doctrine/orm": "^2.10",
         "phpstan/phpstan": "^0.12.93",
         "ramsey/uuid-doctrine": "^1.5",
         "symfony/cache": "^4.4 || ^5.3"

--- a/src/Codeception/Module/Doctrine2.php
+++ b/src/Codeception/Module/Doctrine2.php
@@ -30,7 +30,7 @@ use function gettype;
 use function is_array;
 use function is_object;
 use function is_string;
-use function spl_object_hash;
+use function spl_object_id;
 use function sprintf;
 use function var_export;
 
@@ -442,7 +442,7 @@ EOF;
                 $repositoryListProperty = $reflectedRepositoryFactory->getProperty('repositoryList');
                 $repositoryListProperty->setAccessible(true);
 
-                $repositoryHash = $em->getClassMetadata($className)->getName() . spl_object_hash($em);
+                $repositoryHash = $em->getClassMetadata($className)->getName() . spl_object_id($em);
                 $repositoryListProperty->setValue(
                     $repositoryFactory,
                     [$repositoryHash => $mock]


### PR DESCRIPTION
This change also means 2.10.0 as minimum required doctrine/orm version.
I don't see a reliable way to make it flexible and work for 2.4-2.9 versions.