### PR TITLE
[Codecept5] ReflectionException for constructors requiring no parameters

### DIFF
--- a/src/Codeception/Util/ReflectionPropertyAccessor.php
+++ b/src/Codeception/Util/ReflectionPropertyAccessor.php
@@ -58,7 +58,12 @@ class ReflectionPropertyAccessor
                 }
             }
 
-            $obj = $reflectionClass->newInstance($constructorParameters);
+            // Only provide constructor parameters if the array isn't empty.
+            if (count($constructorParameters) > 0) {
+                $obj = $reflectionClass->newInstance($constructorParameters);
+            } else {
+                $obj = $reflectionClass->newInstance();
+            }
         }
 
         foreach ($reflectionClass->getProperties() as $property) {


### PR DESCRIPTION
**Codeception version:** alpha1
**PHP version:** 8.1.2

I noticed the following error during seeding a class with a constructor which required no parameters (and the same on classes with no defined constructor):

```
[ReflectionException] Class App\Entity\User does not have a constructor, so you cannot pass any constructor arguments
```

Perhaps this is more an issue with ReflectionClass itself for complaining about an empty array for a constructor since one would expect it to skip the constructor parameters array if it's empty, however seemingly this is not the case (I haven't tested with other versions of PHP; only 8.1.2).