### PR TITLE
Fix deprecated string interpolation

### DIFF
--- a/src/Codeception/Module/Doctrine2.php
+++ b/src/Codeception/Module/Doctrine2.php
@@ -971,8 +971,8 @@ EOF;
             if ($data->associationMappings !== null && array_key_exists($key, $data->associationMappings)) {
                 $map = $data->associationMappings[$key];
                 if (is_array($val)) {
-                    $qb->innerJoin("$alias.$key", "${alias}__$key");
-                    $this->_buildAssociationQuery($qb, $map['targetEntity'], "${alias}__$key", $val, $paramIndex);
+                    $qb->innerJoin("$alias.$key", "{$alias}__$key");
+                    $this->_buildAssociationQuery($qb, $map['targetEntity'], "{$alias}__$key", $val, $paramIndex);
                     continue;
                 }
             }


### PR DESCRIPTION
The original syntax used is going to be deprecated in PHP 8.2.

https://php.watch/versions/8.2/$%7Bvar%7D-string-interpolation-deprecated