### PR TITLE
Recommending against `grab()` methods for Symfony users

### DIFF
--- a/src/Codeception/Module/Doctrine2.php
+++ b/src/Codeception/Module/Doctrine2.php
@@ -88,6 +88,24 @@ use function var_export;
  *             purge_mode: 1 # 1: DELETE (=default), 2: TRUNCATE
  * ```
  *
+ * ## Grabbing Entities with Symfony
+ *
+ * For Symfony users, the recommended way to query for entities is not to use this module's `grab...()` methods, but rather
+ * "inject" Doctrine's repository:
+ *
+ * ```php
+ * public function _before(FunctionalTester $I): void
+ * {
+ *     $this->fooRepository = $I->grabService(FooRepository::class);
+ * }
+ * ```
+ *
+ * Now you have access to all your familiar repository methods in your tests, e.g.:
+ *
+ * ```php
+ * $greenFoo = $this->fooRepository->findOneBy(['color' => 'green']);
+ * ```
+ *
  * ## Status
  *
  * * Maintainer: **davert**


### PR DESCRIPTION
Closes https://github.com/Codeception/module-doctrine2/issues/22
Info is taken from https://github.com/Codeception/module-doctrine2/issues/22#issuecomment-1373389613

In case of merge conflict: This is meant to go between "Description" and "Public Properties"

TODO after this is merged: Add a link from the three `grab` methods to this section