### PR TITLE
Support doctrine/orm v3 + doctrine/dbal v4

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -32,4 +32,6 @@ jobs:
       run: php vendor/bin/codecept run
 
     - name: Run source code analysis
+      if: "${{ matrix.composer_flags == '' }}"
       run: php vendor/bin/phpstan
+      

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,7 +8,7 @@ jobs:
 
     strategy:
       matrix:
-        php: [8.0, 8.1, 8.2, 8.3]
+        php: [8.1, 8.2, 8.3]
 
     steps:
     - name: Checkout code

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,6 +9,7 @@ jobs:
     strategy:
       matrix:
         php: [8.1, 8.2, 8.3]
+        composer_flags: [ '', '--prefer-lowest' ]
 
     steps:
     - name: Checkout code
@@ -25,7 +26,7 @@ jobs:
       run: composer validate
 
     - name: Install dependencies
-      run: composer install --prefer-dist --no-progress --no-interaction
+      run: composer update --prefer-dist --no-progress --no-interaction ${{ matrix.composer_flags }}
 
     - name: Run test suite
       run: php vendor/bin/codecept run

--- a/composer.json
+++ b/composer.json
@@ -24,6 +24,7 @@
     },
     "require-dev": {
         "codeception/stub": "^4.1.3",
+        "doctrine/annotations": "^2.0.1",
         "doctrine/data-fixtures": "^1.7",
         "doctrine/orm": "^2.14 || ^3.0",
         "phpstan/phpstan": "^1.10.58",

--- a/composer.json
+++ b/composer.json
@@ -24,11 +24,10 @@
     },
     "require-dev": {
         "codeception/stub": "^4.0",
-        "doctrine/annotations": "^1.13",
         "doctrine/data-fixtures": "^1.5",
-        "doctrine/orm": "^2.10",
+        "doctrine/orm": "^2.14",
         "phpstan/phpstan": "^1.0",
-        "ramsey/uuid-doctrine": "^1.6",
+        "ramsey/uuid-doctrine": "^2.0",
         "symfony/cache": "^4.4 || ^5.4 || ^6.0"
     },
     "conflict": {

--- a/composer.json
+++ b/composer.json
@@ -27,8 +27,9 @@
         "doctrine/data-fixtures": "^1.5",
         "doctrine/orm": "^2.14 || ^3.0",
         "phpstan/phpstan": "^1.0",
-        "ramsey/uuid-doctrine": "^2.0",
-        "symfony/cache": "^4.4 || ^5.4 || ^6.0 || ^7.0"
+        "symfony/cache": "^4.4 || ^5.4 || ^6.0 || ^7.0",
+        "symfony/doctrine-bridge": "^5.4 || ^6.4 || ^7.0",
+        "symfony/uid": "^5.4 || ^6.4 || ^7.0"
     },
     "conflict": {
         "codeception/codeception": "<5.0"

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
     ],
     "homepage": "https://codeception.com/",
     "require": {
-        "php": "^8.0",
+        "php": "^8.1",
         "ext-json": "*",
         "ext-pdo": "*",
         "codeception/codeception": "^5.0.0-alpha2"

--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,7 @@
         "doctrine/orm": "^2.14",
         "phpstan/phpstan": "^1.0",
         "ramsey/uuid-doctrine": "^2.0",
-        "symfony/cache": "^4.4 || ^5.4 || ^6.0"
+        "symfony/cache": "^4.4 || ^5.4 || ^6.0 || ^7.0"
     },
     "conflict": {
         "codeception/codeception": "<5.0"

--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
     "require-dev": {
         "codeception/stub": "^4.0",
         "doctrine/data-fixtures": "^1.5",
-        "doctrine/orm": "^2.14",
+        "doctrine/orm": "^2.14 || ^3.0",
         "phpstan/phpstan": "^1.0",
         "ramsey/uuid-doctrine": "^2.0",
         "symfony/cache": "^4.4 || ^5.4 || ^6.0 || ^7.0"

--- a/composer.json
+++ b/composer.json
@@ -20,19 +20,16 @@
         "php": "^8.1",
         "ext-json": "*",
         "ext-pdo": "*",
-        "codeception/codeception": "^5.0.0-alpha2"
+        "codeception/codeception": "^5.1"
     },
     "require-dev": {
-        "codeception/stub": "^4.0",
-        "doctrine/data-fixtures": "^1.5",
+        "codeception/stub": "^4.1.3",
+        "doctrine/data-fixtures": "^1.7",
         "doctrine/orm": "^2.14 || ^3.0",
-        "phpstan/phpstan": "^1.0",
-        "symfony/cache": "^4.4 || ^5.4 || ^6.0 || ^7.0",
-        "symfony/doctrine-bridge": "^5.4 || ^6.4 || ^7.0",
-        "symfony/uid": "^5.4 || ^6.4 || ^7.0"
-    },
-    "conflict": {
-        "codeception/codeception": "<5.0"
+        "phpstan/phpstan": "^1.10.58",
+        "symfony/cache": "^5.4.35 || ^6.4.3 || ^7.0",
+        "symfony/doctrine-bridge": "^5.4.35 || ^6.4.3 || ^7.0",
+        "symfony/uid": "^5.4.35 || ^6.4.3 || ^7.0"
     },
     "minimum-stability": "dev",
     "autoload": {

--- a/src/Codeception/Module/Doctrine2.php
+++ b/src/Codeception/Module/Doctrine2.php
@@ -257,7 +257,7 @@ EOF;
             );
         }
 
-        $this->em->getConnection()->connect();
+        $this->em->getConnection()->getNativeConnection();
     }
 
     /**

--- a/src/Codeception/Module/Doctrine2.php
+++ b/src/Codeception/Module/Doctrine2.php
@@ -401,10 +401,7 @@ EOF;
 
             $reflectedRepositoryFactory = new ReflectionClass($repositoryFactory);
 
-            // Do not call $reflectedRepositoryFactory->isReadOnly() directly because
-            // phpstan will complain about a non-existing method when using PHP 8.0.
-            // isReadOnly() is available as-of PHP 8.1.
-            if ($reflectedRepositoryFactory->hasMethod('isReadOnly') && $reflectedRepositoryFactory->getMethod('isReadOnly')->invoke(null)) {
+            if ($repositoryFactoryProperty->isReadOnly()) {
                 $this->debugSection(
                     'Warning',
                     'Repository can\'t be mocked, the EntityManager\'s repositoryFactory is readonly'

--- a/tests/data/doctrine2_entities/CircularRelations/A.php
+++ b/tests/data/doctrine2_entities/CircularRelations/A.php
@@ -6,10 +6,19 @@ use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
 use Doctrine\ORM\Mapping as ORM;
 
+/**
+ * @ORM\Entity
+ * @ORM\Table(name="circular_a")
+ */
 #[ORM\Entity]
 #[ORM\Table(name: 'circular_a')]
 class A
 {
+    /**
+     * @ORM\Id
+     * @ORM\Column(type="integer")
+     * @ORM\GeneratedValue
+     */
     #[ORM\Id]
     #[ORM\Column(type: 'integer')]
     #[ORM\GeneratedValue]
@@ -17,6 +26,7 @@ class A
 
     /**
      * @var ArrayCollection
+     * @ORM\OneToMany(targetEntity="C", mappedBy="a")
      */
     #[ORM\OneToMany(targetEntity: C::class, mappedBy: 'a')]
     private Collection $cs;

--- a/tests/data/doctrine2_entities/CircularRelations/A.php
+++ b/tests/data/doctrine2_entities/CircularRelations/A.php
@@ -6,23 +6,19 @@ use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
 use Doctrine\ORM\Mapping as ORM;
 
-/**
- * @ORM\Entity
- * @ORM\Table(name="circular_a")
- */
+#[ORM\Entity]
+#[ORM\Table(name: 'circular_a')]
 class A
 {
-    /**
-     * @ORM\Id
-     * @ORM\Column(type="integer")
-     * @ORM\GeneratedValue
-     */
+    #[ORM\Id]
+    #[ORM\Column(type: 'integer')]
+    #[ORM\GeneratedValue]
     private ?int $id = null;
 
     /**
      * @var ArrayCollection
-     * @ORM\OneToMany(targetEntity="C", mappedBy="a")
      */
+    #[ORM\OneToMany(targetEntity: C::class, mappedBy: 'a')]
     private Collection $cs;
 
     public function __construct()

--- a/tests/data/doctrine2_entities/CircularRelations/B.php
+++ b/tests/data/doctrine2_entities/CircularRelations/B.php
@@ -6,10 +6,19 @@ use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
 use Doctrine\ORM\Mapping as ORM;
 
+/**
+ * @ORM\Entity
+ * @ORM\Table(name="circular_b")
+ */
 #[ORM\Entity]
 #[ORM\Table(name: 'circular_b')]
 class B
 {
+    /**
+     * @ORM\Id
+     * @ORM\Column(type="integer")
+     * @ORM\GeneratedValue
+     */
     #[ORM\Id]
     #[ORM\Column(type: 'integer')]
     #[ORM\GeneratedValue]
@@ -17,6 +26,7 @@ class B
 
     /**
      * @var ArrayCollection
+     * @ORM\OneToMany(targetEntity="C", mappedBy="b")
      */
     #[ORM\OneToMany(targetEntity: C::class, mappedBy: 'b')]
     private Collection $cs;

--- a/tests/data/doctrine2_entities/CircularRelations/B.php
+++ b/tests/data/doctrine2_entities/CircularRelations/B.php
@@ -6,23 +6,19 @@ use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
 use Doctrine\ORM\Mapping as ORM;
 
-/**
- * @ORM\Entity
- * @ORM\Table(name="circular_b")
- */
+#[ORM\Entity]
+#[ORM\Table(name: 'circular_b')]
 class B
 {
-    /**
-     * @ORM\Id
-     * @ORM\Column(type="integer")
-     * @ORM\GeneratedValue
-     */
+    #[ORM\Id]
+    #[ORM\Column(type: 'integer')]
+    #[ORM\GeneratedValue]
     private ?int $id = null;
 
     /**
      * @var ArrayCollection
-     * @ORM\OneToMany(targetEntity="C", mappedBy="b")
      */
+    #[ORM\OneToMany(targetEntity: C::class, mappedBy: 'b')]
     private Collection $cs;
 
     public function __construct()

--- a/tests/data/doctrine2_entities/CircularRelations/C.php
+++ b/tests/data/doctrine2_entities/CircularRelations/C.php
@@ -4,14 +4,26 @@ namespace CircularRelations;
 
 use Doctrine\ORM\Mapping as ORM;
 
+/**
+ * @ORM\Entity
+ * @ORM\Table(name="circular_c")
+ */
 #[ORM\Entity]
 #[ORM\Table(name: 'circular_c')]
 class C
 {
+    /**
+     * @ORM\Id
+     * @ORM\ManyToOne(targetEntity="A", inversedBy="cs", cascade={"persist"})
+     */
     #[ORM\Id]
     #[ORM\ManyToOne(targetEntity: A::class, inversedBy: 'cs', cascade: ['persist'])]
     private ?A $a;
 
+    /**
+     * @ORM\Id
+     * @ORM\ManyToOne(targetEntity="B", inversedBy="cs", cascade={"persist"})
+     */
     #[ORM\Id]
     #[ORM\ManyToOne(targetEntity: B::class, inversedBy: 'cs', cascade: ['persist'])]
     private ?B $b;

--- a/tests/data/doctrine2_entities/CircularRelations/C.php
+++ b/tests/data/doctrine2_entities/CircularRelations/C.php
@@ -4,22 +4,16 @@ namespace CircularRelations;
 
 use Doctrine\ORM\Mapping as ORM;
 
-/**
- * @ORM\Entity
- * @ORM\Table(name="circular_c")
- */
+#[ORM\Entity]
+#[ORM\Table(name: 'circular_c')]
 class C
 {
-    /**
-     * @ORM\Id
-     * @ORM\ManyToOne(targetEntity="A", inversedBy="cs", cascade={"persist"})
-     */
+    #[ORM\Id]
+    #[ORM\ManyToOne(targetEntity: A::class, inversedBy: 'cs', cascade: ['persist'])]
     private ?A $a;
 
-    /**
-     * @ORM\Id
-     * @ORM\ManyToOne(targetEntity="B", inversedBy="cs", cascade={"persist"})
-     */
+    #[ORM\Id]
+    #[ORM\ManyToOne(targetEntity: B::class, inversedBy: 'cs', cascade: ['persist'])]
     private ?B $b;
 
     public function __construct(A $a, B $b)

--- a/tests/data/doctrine2_entities/CompositePrimaryKeyEntity.php
+++ b/tests/data/doctrine2_entities/CompositePrimaryKeyEntity.php
@@ -2,21 +2,14 @@
 
 use Doctrine\ORM\Mapping as ORM;
 
-/**
- * @ORM\Entity
- */
+#[ORM\Entity]
 class CompositePrimaryKeyEntity
 {
-    /**
-     * @ORM\Id
-     * @ORM\Column(type="integer")
-     */
+    #[ORM\Id]
+    #[ORM\Column(type: 'integer')]
     private int $integerPart;
 
-    /**
-     *
-     * @ORM\Id
-     * @ORM\Column(type="string")
-     */
+    #[ORM\Id]
+    #[ORM\Column(type: 'string')]
     private string $stringPart;
 }

--- a/tests/data/doctrine2_entities/CompositePrimaryKeyEntity.php
+++ b/tests/data/doctrine2_entities/CompositePrimaryKeyEntity.php
@@ -2,13 +2,25 @@
 
 use Doctrine\ORM\Mapping as ORM;
 
+/**
+ * @ORM\Entity
+ */
 #[ORM\Entity]
 class CompositePrimaryKeyEntity
 {
+    /**
+     * @ORM\Id
+     * @ORM\Column(type="integer")
+     */
     #[ORM\Id]
     #[ORM\Column(type: 'integer')]
     private int $integerPart;
 
+    /**
+     *
+     * @ORM\Id
+     * @ORM\Column(type="string")
+     */
     #[ORM\Id]
     #[ORM\Column(type: 'string')]
     private string $stringPart;

--- a/tests/data/doctrine2_entities/EntityWithConstructorParameters.php
+++ b/tests/data/doctrine2_entities/EntityWithConstructorParameters.php
@@ -2,31 +2,21 @@
 
 use Doctrine\ORM\Mapping as ORM;
 
-/**
- * @ORM\Entity
- */
+#[ORM\Entity]
 class EntityWithConstructorParameters
 {
-    /**
-     * @ORM\Id
-     * @ORM\Column(type="integer")
-     * @ORM\GeneratedValue
-     */
+    #[ORM\Id]
+    #[ORM\Column(type: 'integer')]
+    #[ORM\GeneratedValue]
     private int $id;
 
-    /**
-     * @ORM\Column(type="string", nullable=true)
-     */
+    #[ORM\Column(type: 'string', nullable: true)]
     private ?string $name = null;
 
-    /**
-     * @ORM\Column(type="string", nullable=true)
-     */
+    #[ORM\Column(type: 'string', nullable: true)]
     private ?string $foo = null;
 
-    /**
-     * @ORM\Column(type="string")
-     */
+    #[ORM\Column(type: 'string')]
     private string $bar = '';
 
     public function __construct($name, $foo = null, $bar = 'foobar')

--- a/tests/data/doctrine2_entities/EntityWithConstructorParameters.php
+++ b/tests/data/doctrine2_entities/EntityWithConstructorParameters.php
@@ -2,20 +2,37 @@
 
 use Doctrine\ORM\Mapping as ORM;
 
+/**
+ * @ORM\Entity
+ */
 #[ORM\Entity]
 class EntityWithConstructorParameters
 {
+    /**
+     * @ORM\Id
+     * @ORM\Column(type="integer")
+     * @ORM\GeneratedValue
+     */
     #[ORM\Id]
     #[ORM\Column(type: 'integer')]
     #[ORM\GeneratedValue]
     private int $id;
 
+    /**
+     * @ORM\Column(type="string", nullable=true)
+     */
     #[ORM\Column(type: 'string', nullable: true)]
     private ?string $name = null;
 
+    /**
+     * @ORM\Column(type="string", nullable=true)
+     */
     #[ORM\Column(type: 'string', nullable: true)]
     private ?string $foo = null;
 
+    /**
+     * @ORM\Column(type="string")
+     */
     #[ORM\Column(type: 'string')]
     private string $bar = '';
 

--- a/tests/data/doctrine2_entities/EntityWithEmbeddable.php
+++ b/tests/data/doctrine2_entities/EntityWithEmbeddable.php
@@ -2,14 +2,26 @@
 
 use Doctrine\ORM\Mapping as ORM;
 
+/**
+ * @ORM\Entity
+ */
 #[ORM\Entity]
 class EntityWithEmbeddable
 {
+    /**
+     *
+     * @ORM\Id
+     * @ORM\Column(type="integer")
+     * @ORM\GeneratedValue
+     */
     #[ORM\Id]
     #[ORM\Column(type: 'integer')]
     #[ORM\GeneratedValue]
     private int $id;
 
+    /**
+     * @ORM\Embedded(class="SampleEmbeddable")
+     */
     #[ORM\Embedded(class: SampleEmbeddable::class)]
     private SampleEmbeddable $embed;
 

--- a/tests/data/doctrine2_entities/EntityWithEmbeddable.php
+++ b/tests/data/doctrine2_entities/EntityWithEmbeddable.php
@@ -2,22 +2,15 @@
 
 use Doctrine\ORM\Mapping as ORM;
 
-/**
- * @ORM\Entity
- */
+#[ORM\Entity]
 class EntityWithEmbeddable
 {
-    /**
-     *
-     * @ORM\Id
-     * @ORM\Column(type="integer")
-     * @ORM\GeneratedValue
-     */
+    #[ORM\Id]
+    #[ORM\Column(type: 'integer')]
+    #[ORM\GeneratedValue]
     private int $id;
 
-    /**
-     * @ORM\Embedded(class="SampleEmbeddable")
-     */
+    #[ORM\Embedded(class: SampleEmbeddable::class)]
     private SampleEmbeddable $embed;
 
     public function __construct()

--- a/tests/data/doctrine2_entities/EntityWithUuid.php
+++ b/tests/data/doctrine2_entities/EntityWithUuid.php
@@ -2,19 +2,16 @@
 
 use Doctrine\ORM\Mapping as ORM;
 use Ramsey\Uuid\Uuid;
+use Ramsey\Uuid\Doctrine\UuidGenerator;
 use Ramsey\Uuid\UuidInterface;
 
-/**
- * @ORM\Entity
- */
+#[ORM\Entity]
 class EntityWithUuid
 {
-    /**
-     * @ORM\Id
-     * @ORM\Column(type="uuid", unique=true)
-     * @ORM\GeneratedValue(strategy="CUSTOM")
-     * @ORM\CustomIdGenerator(class="Ramsey\Uuid\Doctrine\UuidGenerator")
-     */
+    #[ORM\Id]
+    #[ORM\Column(type: 'uuid', unique: true)]
+    #[ORM\GeneratedValue(strategy: 'CUSTOM')]
+    #[ORM\CustomIdGenerator(class: UuidGenerator::class)]
     private ?UuidInterface $id = null;
 
     public function __construct()

--- a/tests/data/doctrine2_entities/EntityWithUuid.php
+++ b/tests/data/doctrine2_entities/EntityWithUuid.php
@@ -4,9 +4,18 @@ use Doctrine\ORM\Mapping as ORM;
 use Symfony\Bridge\Doctrine\IdGenerator\UuidGenerator;
 use Symfony\Component\Uid\Uuid;
 
+/**
+ * @ORM\Entity
+ */
 #[ORM\Entity]
 class EntityWithUuid
 {
+    /**
+     * @ORM\Id
+     * @ORM\Column(type="uuid", unique=true)
+     * @ORM\GeneratedValue(strategy="CUSTOM")
+     * @ORM\CustomIdGenerator(class="Symfony\Bridge\Doctrine\IdGenerator\UuidGenerator")
+     */
     #[ORM\Id]
     #[ORM\Column(type: 'uuid', unique: true)]
     #[ORM\GeneratedValue(strategy: 'CUSTOM')]

--- a/tests/data/doctrine2_entities/EntityWithUuid.php
+++ b/tests/data/doctrine2_entities/EntityWithUuid.php
@@ -1,9 +1,8 @@
 <?php
 
 use Doctrine\ORM\Mapping as ORM;
-use Ramsey\Uuid\Uuid;
-use Ramsey\Uuid\Doctrine\UuidGenerator;
-use Ramsey\Uuid\UuidInterface;
+use Symfony\Bridge\Doctrine\IdGenerator\UuidGenerator;
+use Symfony\Component\Uid\Uuid;
 
 #[ORM\Entity]
 class EntityWithUuid
@@ -12,14 +11,14 @@ class EntityWithUuid
     #[ORM\Column(type: 'uuid', unique: true)]
     #[ORM\GeneratedValue(strategy: 'CUSTOM')]
     #[ORM\CustomIdGenerator(class: UuidGenerator::class)]
-    private ?UuidInterface $id = null;
+    private ?Uuid $id = null;
 
     public function __construct()
     {
-        $this->id = Uuid::uuid4();
+        $this->id = Uuid::v4();
     }
 
-    public function getId(): UuidInterface
+    public function getId(): Uuid
     {
         return $this->id;
     }

--- a/tests/data/doctrine2_entities/JoinedEntity.php
+++ b/tests/data/doctrine2_entities/JoinedEntity.php
@@ -2,9 +2,15 @@
 
 use Doctrine\ORM\Mapping as ORM;
 
+/**
+ * @ORM\Entity
+ */
 #[ORM\Entity]
 class JoinedEntity extends JoinedEntityBase
 {
+    /**
+     * @ORM\Column(type="string", nullable=true)
+     */
     #[ORM\Column(type: 'string', nullable: true)]
     private ?string $own = null;
 }

--- a/tests/data/doctrine2_entities/JoinedEntity.php
+++ b/tests/data/doctrine2_entities/JoinedEntity.php
@@ -2,13 +2,9 @@
 
 use Doctrine\ORM\Mapping as ORM;
 
-/**
- * @ORM\Entity
- */
+#[ORM\Entity]
 class JoinedEntity extends JoinedEntityBase
 {
-    /**
-     * @ORM\Column(type="string", nullable=true)
-     */
+    #[ORM\Column(type: 'string', nullable: true)]
     private ?string $own = null;
 }

--- a/tests/data/doctrine2_entities/JoinedEntityBase.php
+++ b/tests/data/doctrine2_entities/JoinedEntityBase.php
@@ -2,21 +2,15 @@
 
 use Doctrine\ORM\Mapping as ORM;
 
-/**
- * @ORM\Entity
- * @ORM\InheritanceType("JOINED")
- */
+#[ORM\Entity]
+#[ORM\InheritanceType('JOINED')]
 class JoinedEntityBase
 {
-    /**
-     * @ORM\Id
-     * @ORM\Column(type="integer")
-     * @ORM\GeneratedValue
-     */
+    #[ORM\Id]
+    #[ORM\Column(type: 'integer')]
+    #[ORM\GeneratedValue]
     private int $id;
 
-    /**
-     * @ORM\Column(type="string", nullable=true)
-     */
+    #[ORM\Column(type: 'string', nullable: true)]
     private ?string $inherited = null;
 }

--- a/tests/data/doctrine2_entities/JoinedEntityBase.php
+++ b/tests/data/doctrine2_entities/JoinedEntityBase.php
@@ -2,15 +2,27 @@
 
 use Doctrine\ORM\Mapping as ORM;
 
+/**
+ * @ORM\Entity
+ * @ORM\InheritanceType("JOINED")
+ */
 #[ORM\Entity]
 #[ORM\InheritanceType('JOINED')]
 class JoinedEntityBase
 {
+    /**
+     * @ORM\Id
+     * @ORM\Column(type="integer")
+     * @ORM\GeneratedValue
+     */
     #[ORM\Id]
     #[ORM\Column(type: 'integer')]
     #[ORM\GeneratedValue]
     private int $id;
 
+    /**
+     * @ORM\Column(type="string", nullable=true)
+     */
     #[ORM\Column(type: 'string', nullable: true)]
     private ?string $inherited = null;
 }

--- a/tests/data/doctrine2_entities/MultilevelRelations/A.php
+++ b/tests/data/doctrine2_entities/MultilevelRelations/A.php
@@ -6,19 +6,31 @@ use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
 use Doctrine\ORM\Mapping as ORM;
 
+/**
+ * @ORM\Entity
+ */
 #[ORM\Entity]
 class A
 {
+    /**
+     * @ORM\Id
+     * @ORM\Column(type="integer")
+     * @ORM\GeneratedValue
+     */
     #[ORM\Id]
     #[ORM\Column(type: 'integer')]
     #[ORM\GeneratedValue]
     private int $id;
 
+    /**
+     * @ORM\Column(type="string", nullable=true)
+     */
     #[ORM\Column(type: 'string', nullable: true)]
     private ?string $name = null;
 
     /**
      * @var Collection|B[]
+     * @ORM\OneToMany(targetEntity="B", mappedBy="a")
      */
     #[ORM\OneToMany(targetEntity: B::class, mappedBy: 'a')]
     private Collection $b;

--- a/tests/data/doctrine2_entities/MultilevelRelations/A.php
+++ b/tests/data/doctrine2_entities/MultilevelRelations/A.php
@@ -6,27 +6,21 @@ use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
 use Doctrine\ORM\Mapping as ORM;
 
-/**
- * @ORM\Entity
- */
+#[ORM\Entity]
 class A
 {
-    /**
-     * @ORM\Id
-     * @ORM\Column(type="integer")
-     * @ORM\GeneratedValue
-     */
+    #[ORM\Id]
+    #[ORM\Column(type: 'integer')]
+    #[ORM\GeneratedValue]
     private int $id;
 
-    /**
-     * @ORM\Column(type="string", nullable=true)
-     */
+    #[ORM\Column(type: 'string', nullable: true)]
     private ?string $name = null;
 
     /**
      * @var Collection|B[]
-     * @ORM\OneToMany(targetEntity="B", mappedBy="a")
      */
+    #[ORM\OneToMany(targetEntity: B::class, mappedBy: 'a')]
     private Collection $b;
 
     public function __construct()

--- a/tests/data/doctrine2_entities/MultilevelRelations/B.php
+++ b/tests/data/doctrine2_entities/MultilevelRelations/B.php
@@ -6,33 +6,24 @@ use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
 use Doctrine\ORM\Mapping as ORM;
 
-/**
- * @ORM\Entity
- */
+#[ORM\Entity]
 class B
 {
-    /**
-     * @ORM\Id
-     * @ORM\Column(type="integer")
-     * @ORM\GeneratedValue
-     */
+    #[ORM\Id]
+    #[ORM\Column(type: 'integer')]
+    #[ORM\GeneratedValue]
     private int $id;
 
-    /**
-     * @ORM\Column(type="string", nullable=true)
-     */
+    #[ORM\Column(type: 'string', nullable: true)]
     private ?string $name = null;
 
-    /**
-     * @ORM\ManyToOne(targetEntity="A")
-     */
+    #[ORM\ManyToOne(targetEntity: A::class)]
     private ?A $a = null;
 
     /**
      * @var Collection|C[]
-     *
-     * @ORM\OneToMany(targetEntity="C", mappedBy="b")
      */
+    #[ORM\OneToMany(targetEntity: C::class, mappedBy: 'b')]
     private Collection $c;
 
     public function __construct()

--- a/tests/data/doctrine2_entities/MultilevelRelations/B.php
+++ b/tests/data/doctrine2_entities/MultilevelRelations/B.php
@@ -6,22 +6,38 @@ use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
 use Doctrine\ORM\Mapping as ORM;
 
+/**
+ * @ORM\Entity
+ */
 #[ORM\Entity]
 class B
 {
+    /**
+     * @ORM\Id
+     * @ORM\Column(type="integer")
+     * @ORM\GeneratedValue
+     */
     #[ORM\Id]
     #[ORM\Column(type: 'integer')]
     #[ORM\GeneratedValue]
     private int $id;
 
+    /**
+     * @ORM\Column(type="string", nullable=true)
+     */
     #[ORM\Column(type: 'string', nullable: true)]
     private ?string $name = null;
 
+    /**
+     * @ORM\ManyToOne(targetEntity="A")
+     */
     #[ORM\ManyToOne(targetEntity: A::class)]
     private ?A $a = null;
 
     /**
      * @var Collection|C[]
+     *
+     * @ORM\OneToMany(targetEntity="C", mappedBy="b")
      */
     #[ORM\OneToMany(targetEntity: C::class, mappedBy: 'b')]
     private Collection $c;

--- a/tests/data/doctrine2_entities/MultilevelRelations/C.php
+++ b/tests/data/doctrine2_entities/MultilevelRelations/C.php
@@ -4,17 +4,31 @@ namespace MultilevelRelations;
 
 use Doctrine\ORM\Mapping as ORM;
 
+/**
+ * @ORM\Entity
+ */
 #[ORM\Entity]
 class C
 {
+    /**
+     * @ORM\Id
+     * @ORM\Column(type="integer")
+     * @ORM\GeneratedValue
+     */
     #[ORM\Id]
     #[ORM\Column(type: 'integer')]
     #[ORM\GeneratedValue]
     private int $id;
 
+    /**
+     * @ORM\Column(type="string", nullable=true)
+     */
     #[ORM\Column(type: 'string', nullable: true)]
     private ?string $name = null;
 
+    /**
+     * @ORM\ManyToOne(targetEntity="B")
+     */
     #[ORM\ManyToOne(targetEntity: B::class)]
     private ?B $b = null;
 

--- a/tests/data/doctrine2_entities/MultilevelRelations/C.php
+++ b/tests/data/doctrine2_entities/MultilevelRelations/C.php
@@ -4,26 +4,18 @@ namespace MultilevelRelations;
 
 use Doctrine\ORM\Mapping as ORM;
 
-/**
- * @ORM\Entity
- */
+#[ORM\Entity]
 class C
 {
-    /**
-     * @ORM\Id
-     * @ORM\Column(type="integer")
-     * @ORM\GeneratedValue
-     */
+    #[ORM\Id]
+    #[ORM\Column(type: 'integer')]
+    #[ORM\GeneratedValue]
     private int $id;
 
-    /**
-     * @ORM\Column(type="string", nullable=true)
-     */
+    #[ORM\Column(type: 'string', nullable: true)]
     private ?string $name = null;
 
-    /**
-     * @ORM\ManyToOne(targetEntity="B")
-     */
+    #[ORM\ManyToOne(targetEntity: B::class)]
     private ?B $b = null;
 
     public function getB(): ?B

--- a/tests/data/doctrine2_entities/NonTypicalPrimaryKeyEntity.php
+++ b/tests/data/doctrine2_entities/NonTypicalPrimaryKeyEntity.php
@@ -2,14 +2,10 @@
 
 use Doctrine\ORM\Mapping as ORM;
 
-/**
- * @ORM\Entity
- */
+#[ORM\Entity]
 class NonTypicalPrimaryKeyEntity
 {
-    /**
-     * @ORM\Id
-     * @ORM\Column(type="string")
-     */
+    #[ORM\Id]
+    #[ORM\Column(type: 'string')]
     private string $primaryKey;
 }

--- a/tests/data/doctrine2_entities/NonTypicalPrimaryKeyEntity.php
+++ b/tests/data/doctrine2_entities/NonTypicalPrimaryKeyEntity.php
@@ -2,9 +2,16 @@
 
 use Doctrine\ORM\Mapping as ORM;
 
+/**
+ * @ORM\Entity
+ */
 #[ORM\Entity]
 class NonTypicalPrimaryKeyEntity
 {
+    /**
+     * @ORM\Id
+     * @ORM\Column(type="string")
+     */
     #[ORM\Id]
     #[ORM\Column(type: 'string')]
     private string $primaryKey;

--- a/tests/data/doctrine2_entities/PlainEntity.php
+++ b/tests/data/doctrine2_entities/PlainEntity.php
@@ -2,14 +2,25 @@
 
 use Doctrine\ORM\Mapping as ORM;
 
+/**
+ * @ORM\Entity
+ */
 #[ORM\Entity]
 class PlainEntity
 {
+    /**
+     * @ORM\Id
+     * @ORM\Column(type="integer")
+     * @ORM\GeneratedValue
+     */
     #[ORM\Id]
     #[ORM\Column(type: 'integer')]
     #[ORM\GeneratedValue]
     private ?int $id = null;
 
+    /**
+     * @ORM\Column(type="string", nullable=true)
+     */
     #[ORM\Column(type: 'string', nullable: true)]
     private ?string $name = null;
 

--- a/tests/data/doctrine2_entities/PlainEntity.php
+++ b/tests/data/doctrine2_entities/PlainEntity.php
@@ -2,21 +2,15 @@
 
 use Doctrine\ORM\Mapping as ORM;
 
-/**
- * @ORM\Entity
- */
+#[ORM\Entity]
 class PlainEntity
 {
-    /**
-     * @ORM\Id
-     * @ORM\Column(type="integer")
-     * @ORM\GeneratedValue
-     */
+    #[ORM\Id]
+    #[ORM\Column(type: 'integer')]
+    #[ORM\GeneratedValue]
     private ?int $id = null;
 
-    /**
-     * @ORM\Column(type="string", nullable=true)
-     */
+    #[ORM\Column(type: 'string', nullable: true)]
     private ?string $name = null;
 
     public function getId(): ?int

--- a/tests/data/doctrine2_entities/QuirkyFieldName/Association.php
+++ b/tests/data/doctrine2_entities/QuirkyFieldName/Association.php
@@ -4,21 +4,15 @@ namespace QuirkyFieldName;
 
 use Doctrine\ORM\Mapping as ORM;
 
-/**
- * @ORM\Entity
- */
+#[ORM\Entity]
 class Association
 {
-    /**
-     * @ORM\Id
-     * @ORM\Column(type="integer")
-     * @ORM\GeneratedValue
-     */
+    #[ORM\Id]
+    #[ORM\Column(type: 'integer')]
+    #[ORM\GeneratedValue]
     private ?int $id = null;
 
-    /**
-     * @ORM\Column(type="string", nullable=true)
-     */
+    #[ORM\Column(type: 'string', nullable: true)]
     private ?string $val = null;
 
     public function getId(): ?int

--- a/tests/data/doctrine2_entities/QuirkyFieldName/Association.php
+++ b/tests/data/doctrine2_entities/QuirkyFieldName/Association.php
@@ -4,14 +4,25 @@ namespace QuirkyFieldName;
 
 use Doctrine\ORM\Mapping as ORM;
 
+/**
+ * @ORM\Entity
+ */
 #[ORM\Entity]
 class Association
 {
+    /**
+     * @ORM\Id
+     * @ORM\Column(type="integer")
+     * @ORM\GeneratedValue
+     */
     #[ORM\Id]
     #[ORM\Column(type: 'integer')]
     #[ORM\GeneratedValue]
     private ?int $id = null;
 
+    /**
+     * @ORM\Column(type="string", nullable=true)
+     */
     #[ORM\Column(type: 'string', nullable: true)]
     private ?string $val = null;
 

--- a/tests/data/doctrine2_entities/QuirkyFieldName/AssociationHost.php
+++ b/tests/data/doctrine2_entities/QuirkyFieldName/AssociationHost.php
@@ -4,17 +4,31 @@ namespace QuirkyFieldName;
 
 use Doctrine\ORM\Mapping as ORM;
 
+/**
+ * @ORM\Entity
+ */
 #[ORM\Entity]
 class AssociationHost
 {
+    /**
+     * @ORM\Id
+     * @ORM\Column(type="integer")
+     * @ORM\GeneratedValue
+     */
     #[ORM\Id]
     #[ORM\Column(type: 'integer')]
     #[ORM\GeneratedValue]
     private ?int $id = null;
 
+    /**
+     * @ORM\OneToOne(targetEntity="Association")
+     */
     #[ORM\OneToOne(targetEntity: Association::class)]
     private ?Association $assoc = null;
 
+    /**
+     * @ORM\Column(type="string", nullable=true)
+     */
     #[ORM\Column(type: 'string', nullable: true)]
     private ?string $_assoc_val = null;
 

--- a/tests/data/doctrine2_entities/QuirkyFieldName/AssociationHost.php
+++ b/tests/data/doctrine2_entities/QuirkyFieldName/AssociationHost.php
@@ -4,26 +4,18 @@ namespace QuirkyFieldName;
 
 use Doctrine\ORM\Mapping as ORM;
 
-/**
- * @ORM\Entity
- */
+#[ORM\Entity]
 class AssociationHost
 {
-    /**
-     * @ORM\Id
-     * @ORM\Column(type="integer")
-     * @ORM\GeneratedValue
-     */
+    #[ORM\Id]
+    #[ORM\Column(type: 'integer')]
+    #[ORM\GeneratedValue]
     private ?int $id = null;
 
-    /**
-     * @ORM\OneToOne(targetEntity="Association")
-     */
+    #[ORM\OneToOne(targetEntity: Association::class)]
     private ?Association $assoc = null;
 
-    /**
-     * @ORM\Column(type="string", nullable=true)
-     */
+    #[ORM\Column(type: 'string', nullable: true)]
     private ?string $_assoc_val = null;
 
     public function getId(): ?int

--- a/tests/data/doctrine2_entities/QuirkyFieldName/Embeddable.php
+++ b/tests/data/doctrine2_entities/QuirkyFieldName/Embeddable.php
@@ -4,13 +4,9 @@ namespace QuirkyFieldName;
 
 use Doctrine\ORM\Mapping as ORM;
 
-/**
- * @ORM\Embeddable
- */
+#[ORM\Embeddable]
 class Embeddable
 {
-    /**
-     * @ORM\Column(type="string", nullable=true)
-     */
+    #[ORM\Column(type: 'string', nullable: true)]
     private ?string $val = null;
 }

--- a/tests/data/doctrine2_entities/QuirkyFieldName/Embeddable.php
+++ b/tests/data/doctrine2_entities/QuirkyFieldName/Embeddable.php
@@ -4,9 +4,15 @@ namespace QuirkyFieldName;
 
 use Doctrine\ORM\Mapping as ORM;
 
+/**
+ * @ORM\Embeddable
+ */
 #[ORM\Embeddable]
 class Embeddable
 {
+    /**
+     * @ORM\Column(type="string", nullable=true)
+     */
     #[ORM\Column(type: 'string', nullable: true)]
     private ?string $val = null;
 }

--- a/tests/data/doctrine2_entities/QuirkyFieldName/EmbeddableHost.php
+++ b/tests/data/doctrine2_entities/QuirkyFieldName/EmbeddableHost.php
@@ -4,17 +4,31 @@ namespace QuirkyFieldName;
 
 use Doctrine\ORM\Mapping as ORM;
 
+/**
+ * @ORM\Entity
+ */
 #[ORM\Entity]
 class EmbeddableHost
 {
+    /**
+     * @ORM\Id
+     * @ORM\Column(type="integer")
+     * @ORM\GeneratedValue
+     */
     #[ORM\Id]
     #[ORM\Column(type: 'integer')]
     #[ORM\GeneratedValue]
     private int $id;
 
+    /**
+     * @ORM\Embedded(class="Embeddable")
+     */
     #[ORM\Embedded(class: Embeddable::class)]
     private Embeddable $embed;
 
+    /**
+     * @ORM\Column(type="string", nullable=true)
+     */
     #[ORM\Column(type: 'string', nullable: true)]
     private ?string $embedval = null;
 

--- a/tests/data/doctrine2_entities/QuirkyFieldName/EmbeddableHost.php
+++ b/tests/data/doctrine2_entities/QuirkyFieldName/EmbeddableHost.php
@@ -4,26 +4,18 @@ namespace QuirkyFieldName;
 
 use Doctrine\ORM\Mapping as ORM;
 
-/**
- * @ORM\Entity
- */
+#[ORM\Entity]
 class EmbeddableHost
 {
-    /**
-     * @ORM\Id
-     * @ORM\Column(type="integer")
-     * @ORM\GeneratedValue
-     */
+    #[ORM\Id]
+    #[ORM\Column(type: 'integer')]
+    #[ORM\GeneratedValue]
     private int $id;
 
-    /**
-     * @ORM\Embedded(class="Embeddable")
-     */
+    #[ORM\Embedded(class: Embeddable::class)]
     private Embeddable $embed;
 
-    /**
-     * @ORM\Column(type="string", nullable=true)
-     */
+    #[ORM\Column(type: 'string', nullable: true)]
     private ?string $embedval = null;
 
     public function __construct()

--- a/tests/data/doctrine2_entities/SampleEmbeddable.php
+++ b/tests/data/doctrine2_entities/SampleEmbeddable.php
@@ -2,13 +2,9 @@
 
 use Doctrine\ORM\Mapping as ORM;
 
-/**
- * @ORM\Embeddable
- */
+#[ORM\Embeddable]
 class SampleEmbeddable
 {
-    /**
-     * @ORM\Column(type="string", nullable=true)
-     */
+    #[ORM\Column(type: 'string', nullable: true)]
     private ?string $val = null;
 }

--- a/tests/data/doctrine2_entities/SampleEmbeddable.php
+++ b/tests/data/doctrine2_entities/SampleEmbeddable.php
@@ -2,9 +2,15 @@
 
 use Doctrine\ORM\Mapping as ORM;
 
+/**
+ * @ORM\Embeddable
+ */
 #[ORM\Embeddable]
 class SampleEmbeddable
 {
+    /**
+     * @ORM\Column(type="string", nullable=true)
+     */
     #[ORM\Column(type: 'string', nullable: true)]
     private ?string $val = null;
 }

--- a/tests/unit/Codeception/Module/Doctrine2Test.php
+++ b/tests/unit/Codeception/Module/Doctrine2Test.php
@@ -11,11 +11,12 @@ use Doctrine\Common\Collections\Criteria;
 use Doctrine\Common\DataFixtures\Executor\ORMExecutor;
 use Doctrine\Common\DataFixtures\Loader;
 use Doctrine\Common\DataFixtures\Purger\ORMPurger;
+use Doctrine\DBAL\DriverManager;
 use Doctrine\DBAL\Types\Type;
 use Doctrine\ORM\EntityManager;
-use Doctrine\ORM\ORMException;
+use Doctrine\ORM\Exception\ORMException;
+use Doctrine\ORM\ORMSetup;
 use Doctrine\ORM\Tools\SchemaTool;
-use Doctrine\ORM\Tools\Setup;
 use MultilevelRelations\A;
 use MultilevelRelations\B;
 use MultilevelRelations\C;
@@ -48,10 +49,6 @@ final class Doctrine2Test extends Unit
             $this->markTestSkipped('doctrine/orm is not installed');
         }
 
-        if (!class_exists(Doctrine\Common\Annotations\Annotation::class)) {
-            $this->markTestSkipped('doctrine/annotations is not installed');
-        }
-
         $dir = __DIR__ . "/../../../data/doctrine2_entities";
 
         require_once $dir . "/CompositePrimaryKeyEntity.php";
@@ -73,10 +70,9 @@ final class Doctrine2Test extends Unit
         require_once $dir . "/CircularRelations/C.php";
         require_once $dir . '/EntityWithUuid.php';
 
-
-        $this->em = EntityManager::create(
-            ['url' => 'sqlite:///:memory:'],
-            Setup::createAnnotationMetadataConfiguration([$dir], true, null, null, false)
+        $this->em = new EntityManager(
+            DriverManager::getConnection(['url' => 'sqlite:///:memory:']),
+            ORMSetup::createAttributeMetadataConfiguration([$dir], true)
         );
 
         (new SchemaTool($this->em))->createSchema([

--- a/tests/unit/Codeception/Module/Doctrine2Test.php
+++ b/tests/unit/Codeception/Module/Doctrine2Test.php
@@ -25,8 +25,8 @@ use QuirkyFieldName\Association;
 use QuirkyFieldName\AssociationHost;
 use QuirkyFieldName\Embeddable;
 use QuirkyFieldName\EmbeddableHost;
-use Ramsey\Uuid\Doctrine\UuidType;
-use Ramsey\Uuid\UuidInterface;
+use Symfony\Bridge\Doctrine\Types\UuidType;
+use Symfony\Component\Uid\Uuid;
 
 final class Doctrine2Test extends Unit
 {
@@ -418,13 +418,13 @@ final class Doctrine2Test extends Unit
 
     /**
      * The purpose of this test is to verify that entites with object @id, that are
-     * not entites itself, e.g. Ramsey\Uuid\UuidInterface, don't break the debug message.
+     * not entites itself, e.g. Symfony\Component\Uid\Uuid, don't break the debug message.
      */
     public function testDebugEntityWithNonEntityButObjectId()
     {
         $pk = $this->module->haveInRepository(EntityWithUuid::class);
 
-        self::assertInstanceOf(UuidInterface::class, $pk);
+        self::assertInstanceOf(Uuid::class, $pk);
     }
 
     public function testRefresh()

--- a/tests/unit/Codeception/Module/Doctrine2Test.php
+++ b/tests/unit/Codeception/Module/Doctrine2Test.php
@@ -71,10 +71,20 @@ final class Doctrine2Test extends Unit
         require_once $dir . "/CircularRelations/C.php";
         require_once $dir . '/EntityWithUuid.php';
 
-        $this->em = new EntityManager(
-            DriverManager::getConnection(['driver' => 'sqlite3', 'memory' => true]),
-            ORMSetup::createAttributeMetadataConfiguration([$dir], true)
-        );
+        $connection = DriverManager::getConnection(['driver' => 'sqlite3', 'memory' => true]);
+        
+        if (version_compare(InstalledVersions::getVersion('doctrine/orm'), '3', '>=')) {
+            $this->em = new EntityManager(
+                $connection,
+                ORMSetup::createAttributeMetadataConfiguration([$dir], true)
+            );
+        } else {
+            $this->em = new EntityManager(
+                $connection,
+                // @phpstan-ignore-next-line
+                ORMSetup::createAnnotationMetadataConfiguration([$dir], true)
+            );
+        }
 
         (new SchemaTool($this->em))->createSchema([
             $this->em->getClassMetadata(CompositePrimaryKeyEntity::class),

--- a/tests/unit/Codeception/Module/Doctrine2Test.php
+++ b/tests/unit/Codeception/Module/Doctrine2Test.php
@@ -2,6 +2,7 @@
 
 declare(strict_types=1);
 
+use Composer\InstalledVersions;
 use Codeception\Exception\ModuleException;
 use Codeception\Lib\ModuleContainer;
 use Codeception\Module\Doctrine2;
@@ -564,6 +565,10 @@ final class Doctrine2Test extends Unit
 
     public function testHaveFakeRepository()
     {
+        if (version_compare(InstalledVersions::getVersion('doctrine/orm'), '3', '>=')) {
+            $this->markTestSkipped('haveFakeRepository() is not supported for doctrine/orm:3 or higher');
+        }
+
         $e1 = new PlainEntity();
         $e2 = new PlainEntity();
         $this->module->haveFakeRepository(PlainEntity::class, [

--- a/tests/unit/Codeception/Module/Doctrine2Test.php
+++ b/tests/unit/Codeception/Module/Doctrine2Test.php
@@ -13,7 +13,6 @@ use Doctrine\Common\DataFixtures\Executor\ORMExecutor;
 use Doctrine\Common\DataFixtures\Loader;
 use Doctrine\Common\DataFixtures\Purger\ORMPurger;
 use Doctrine\DBAL\DriverManager;
-use Doctrine\DBAL\Tools\DsnParser;
 use Doctrine\DBAL\Types\Type;
 use Doctrine\ORM\EntityManager;
 use Doctrine\ORM\Exception\ORMException;
@@ -72,9 +71,8 @@ final class Doctrine2Test extends Unit
         require_once $dir . "/CircularRelations/C.php";
         require_once $dir . '/EntityWithUuid.php';
 
-        $dsnParser = new DsnParser();
         $this->em = new EntityManager(
-            DriverManager::getConnection($dsnParser->parse('sqlite3:///:memory:')),
+            DriverManager::getConnection(['driver' => 'sqlite3', 'memory' => true]),
             ORMSetup::createAttributeMetadataConfiguration([$dir], true)
         );
 


### PR DESCRIPTION
closes Codeception/module-doctrine#1 

closes Codeception/module-doctrine#4 

I cherry-picked the commits from https://github.com/Codeception/module-doctrine2/pull/73 (fixes a deprecation when using ORM v2) and https://github.com/Codeception/module-doctrine2/pull/76 (runs tests with PHP 8.2 and 8.3).